### PR TITLE
crypto: AES CBC encrypt with bytes and PKCS7 padding

### DIFF
--- a/src/main/java/org/crypto/sse/CryptoPrimitives.java
+++ b/src/main/java/org/crypto/sse/CryptoPrimitives.java
@@ -261,7 +261,7 @@ public class CryptoPrimitives {
 
 		IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
 		SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
-		Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding", "BC");
+		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding", "BC");
 		cipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
 		ByteArrayInputStream bIn = new ByteArrayInputStream(input);
 		CipherInputStream cIn = new CipherInputStream(bIn, cipher);
@@ -296,7 +296,7 @@ public class CryptoPrimitives {
 
 		IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
 		SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
-		Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding", "BC");
+		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding", "BC");
 
 		// Initalization of the Cipher
 		cipher.init(Cipher.DECRYPT_MODE, key, ivSpec);

--- a/src/main/java/org/crypto/sse/CryptoPrimitives.java
+++ b/src/main/java/org/crypto/sse/CryptoPrimitives.java
@@ -249,11 +249,15 @@ public class CryptoPrimitives {
 
 	// ***********************************************************************************************//
 
-	public static byte[] encryptAES_CBC(byte[] keyBytes, byte[] ivBytes, String identifier)
+	public static byte[] encryptAES_CBC_String(byte[] keyBytes, byte[] ivBytes, String identifier)
 			throws InvalidKeyException, InvalidAlgorithmParameterException, NoSuchAlgorithmException,
 			NoSuchProviderException, NoSuchPaddingException, IOException {
+	    return encryptAES_CBC(keyBytes, ivBytes, identifier.getBytes("UTF-8"));
+	}
 
-		byte[] input = identifier.getBytes("UTF-8");
+	public static byte[] encryptAES_CBC(byte[] keyBytes, byte[] ivBytes, byte[] input)
+			throws InvalidKeyException, InvalidAlgorithmParameterException, NoSuchAlgorithmException,
+			NoSuchProviderException, NoSuchPaddingException, IOException {
 
 		IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
 		SecretKeySpec key = new SecretKeySpec(keyBytes, "AES");
@@ -270,7 +274,6 @@ public class CryptoPrimitives {
 		byte[] cipherText = concat(ivBytes, bOut.toByteArray());
 
 		return cipherText;
-
 	}
 
 	// ***********************************************************************************************//


### PR DESCRIPTION
In order to handle different higher-level data types such as in SQL, we
also want to work with just raw bytes.  For example, SQL integers and
doubles can be directly interpreted as bytes instead of converting to
UTF-8 string first.

Added PKCS7 padding.