### PR TITLE
Do not require secret key on resolve

### DIFF
--- a/src/main/java/org/crypto/sse/DynRH.java
+++ b/src/main/java/org/crypto/sse/DynRH.java
@@ -9,7 +9,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,7 +20,7 @@
 
 /////////////////////				Response Hiding with add and delete operations					///////////
 
-//***********************************************************************************************//	
+//***********************************************************************************************//
 
 package org.crypto.sse;
 
@@ -197,11 +197,10 @@ public class DynRH {
 
 	// ***********************************************************************************************//
 
-	public static List<String> resolve(byte[] key, List<byte[]> list)
+	public static List<String> resolve(byte[] key2, List<byte[]> list)
 			throws InvalidKeyException, InvalidAlgorithmParameterException, NoSuchAlgorithmException,
 			NoSuchProviderException, NoSuchPaddingException, IOException {
 
-		byte[] key2 = CryptoPrimitives.generateCmac(key, 1 + new String());
 		List<String> result = new ArrayList<String>();
 
 		for (byte[] ct : list) {

--- a/src/test/java/org/crypto/sse/TestLocalDynRH.java
+++ b/src/test/java/org/crypto/sse/TestLocalDynRH.java
@@ -15,7 +15,7 @@ import com.google.common.collect.TreeMultimap;
 public class TestLocalDynRH {
 
 	public static void main(String[] args) throws Exception {
-		
+
 		Printer.addPrinter(new Printer(Printer.LEVEL.EXTRA));
 
 		BufferedReader keyRead = new BufferedReader(new InputStreamReader(System.in));
@@ -94,7 +94,8 @@ public class TestLocalDynRH {
 				byte[][] token = DynRH.genTokenFS(sk, keyword);
 				// start
 				startTime = System.nanoTime();
-				List<String> result = DynRH.resolve(sk, DynRH.queryFS(token, emm));
+				byte[] key2 = CryptoPrimitives.generateCmac(sk, 1 + new String());
+				List<String> result = DynRH.resolve(key2, DynRH.queryFS(token, emm));
 				System.out.println(result);
 				// end
 				endTime = System.nanoTime();
@@ -119,7 +120,8 @@ public class TestLocalDynRH {
 				byte[][] token = DynRH.genToken(sk, keyword);
 				// start
 				startTime = System.nanoTime();
-				List<String> result = DynRH.resolve(sk, DynRH.query(token, emm));
+				byte[] key2 = CryptoPrimitives.generateCmac(sk, 1 + new String());
+				List<String> result = DynRH.resolve(key2, DynRH.query(token, emm));
 				System.out.println(result);
 				// end
 				endTime = System.nanoTime();


### PR DESCRIPTION
I found that `DynRH.resolve` operation requires secret key for search, which does not allow to implement an honest client-server search, as far as server should not have access to secret key. 